### PR TITLE
propagate the 'original generator track ID', if it exists

### DIFF
--- a/python/edep2supera/utils.py
+++ b/python/edep2supera/utils.py
@@ -56,6 +56,8 @@ def larcv_particle(p):
     
     # particle's info setter
     larp.track_id         (p.part.trackid)
+    if hasattr(p.part, "genid") and hasattr(larp, "gen_id"):
+        larp.gen_id(p.part.genid)
     larp.pdg_code         (p.part.pdg)
     larp.momentum         (p.part.px,p.part.py,p.part.pz)
     


### PR DESCRIPTION
This field will correspond to the original generator (read: GENIE)'s track index. In DUNE 2x2, the edep-sim step of the simulation renumbers the ids that wind up in trackid. Not having the original GENIE index makes some truth matching difficult.